### PR TITLE
feat: do not strip /xa0 (nbsp) when removing duplicate whitespace #29743

### DIFF
--- a/src/NHI.PortableText/BlockUtilities.cs
+++ b/src/NHI.PortableText/BlockUtilities.cs
@@ -41,7 +41,7 @@ namespace NHI.PortableText
         /// </summary>
         public static string HtmlDecode(string html)
         {
-            return HttpUtility.HtmlDecode(Regex.Replace(html, @"\s+", " "));
+            return HttpUtility.HtmlDecode(Regex.Replace(html, @"[^\S\xa0]+", " ")); //Changed to not touch non-breaking spaces
         }
 
         /// <summary>


### PR DESCRIPTION
After changing to an updated editor in the CMS that use Unicode xa0 to represent non-breaking space instead of the HTML encoding &nbsp; we lost nbsps on publishing and conversion to Portable Text due to the whitespace reducing HtmlDecode function override. The regex has been rewritten to account for this.